### PR TITLE
fixed: error on Odoo version 13 & 14

### DIFF
--- a/hello_world_view/models/ir_action.py
+++ b/hello_world_view/models/ir_action.py
@@ -5,4 +5,4 @@ from odoo import fields, models
 class ActWindowView(models.Model):
     _inherit = 'ir.actions.act_window.view'
 
-    view_mode = fields.Selection(selection_add=[('hello_world', "Hello World")])
+    view_mode = fields.Selection(selection_add=[('hello_world', "Hello World")], ondelete={'hello_world': 'cascade'})

--- a/hello_world_view/models/ir_ui_view.py
+++ b/hello_world_view/models/ir_ui_view.py
@@ -5,4 +5,4 @@ from odoo import fields, models
 class View(models.Model):
     _inherit = 'ir.ui.view'
 
-    type = fields.Selection(selection_add=[('hello_world', "Hello World")])
+    type = fields.Selection(selection_add=[('hello_world', "Hello World")], ondelete={'hello_world': 'cascade'})

--- a/hello_world_view/static/src/js/hello_world_view.js
+++ b/hello_world_view/static/src/js/hello_world_view.js
@@ -7,6 +7,9 @@ var AbstractModel = require('web.AbstractModel');
 var AbstractRenderer = require('web.AbstractRenderer');
 var AbstractView = require('web.AbstractView');
 var viewRegistry = require('web.view_registry');
+	
+const ControlPanel = require('web.ControlPanel');
+const SearchPanel = require("web/static/src/js/views/search_panel.js");
 
 
 var HelloWorldController = AbstractController.extend({});
@@ -104,6 +107,8 @@ var HelloWorldView = AbstractView.extend({
         Model: HelloWorldModel,
         Controller: HelloWorldController,
         Renderer: HelloWorldRenderer,
+	ControlPanel: ControlPanel,
+        SearchPanel: SearchPanel,
     },
     cssLibs: [
         '/hello_world_view/static/lib/leaflet/leaflet.css'


### PR DESCRIPTION
fixed view error on odoo version 13 & 14 due to there is the absent of ControlPanel and SearchPanel:
```
Traceback:
TypeError: Cannot read property 'modelExtension' of undefined
    at Class.init (http://localhost:8069/web/static/src/js/views/abstract_view.js:201:72)
    at Class.prototype.<computed> [as init] (http://localhost:8069/web/static/src/js/core/class.js:90:38)
    at Class.init (http://localhost:8069/hello_world_view/static/src/js/hello_world_view.js:118:21)
    at Class.prototype.<computed> [as init] (http://localhost:8069/web/static/src/js/core/class.js:90:38)
    at new Class (http://localhost:8069/web/static/src/js/core/class.js:107:33)
    at Class._createViewController (http://localhost:8069/web/static/src/js/chrome/action_manager_act_window.js:191:24)
    at http://localhost:8069/web/static/src/js/chrome/action_manager_act_window.js:306:43

```

To fixed this error, I have load ControlPanel and SearchPanel as below:

```
const ControlPanel = require('web.ControlPanel');
const SearchPanel = require("web/static/src/js/views/search_panel.js");


var MyView = AbstractView.extend({
        config: {
            Model: MyModel,
            Controller: MyController,
            Renderer: MyRenderer,
            ControlPanel: ControlPanel,
            SearchPanel: SearchPanel,
        },
})
```